### PR TITLE
Change attribution for jitai dictionary

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -905,7 +905,7 @@ A kanji dictionary made from the kanji variant information in
 
 **[Download](https://github.com/MarvNC/yomichan-dictionaries/raw/master/dl/%5BKanji%5D%20jitai.zip)**
 
-A kanji dictionary made using the data from [jitai](https://github.com/epistularum/jitai). This
+A kanji dictionary made using the data from [shinjigen-glyph](https://github.com/metasta/shinjigen-glyph). This
 allows you to see information about 旧字体, 新字体, 拡張新字体, and 標準字体 variants from the kanji
 page in Yomichan.
 


### PR DESCRIPTION
Currently, it is attributed to me, but I only re-ordered the data. All the work was done by metasta.

On another note, I have compiled much more jitai data in my [new project](https://github.com/epistularum/kanji-restoration/tree/main/source).  It now covers 4 dictionaries instead of only 新字源. The original jitai project was deleted because I was not entirely satisfied with the quality of the data. The new data is compiled directly from the mdx dictionaries.